### PR TITLE
Implement Steam support to detect paths.

### DIFF
--- a/COM3D2_DLC_Checker.csproj
+++ b/COM3D2_DLC_Checker.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ApplicationIcon>lc_1_z07_icon.ico</ApplicationIcon>
     <Authors>Tankerch</Authors>
     <PackageProjectUrl></PackageProjectUrl>
@@ -12,7 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
+    <PackageReference Include="GameFinder.StoreHandlers.Steam" Version="4.5.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Include="NexusMods.Paths" Version="0.15.0" />
   </ItemGroup>
 
 </Project>

--- a/Program.cs
+++ b/Program.cs
@@ -5,6 +5,10 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using Microsoft.Win32;
+using GameFinder.RegistryUtils;
+using GameFinder.StoreHandlers.Steam;
+using GameFinder.StoreHandlers.Steam.Models.ValueTypes;
+using NexusMods.Paths;
 
 namespace COM3D2_DLC_Checker
 {
@@ -15,6 +19,8 @@ namespace COM3D2_DLC_Checker
         // Variables
         static readonly string DLC_URL = "https://raw.githubusercontent.com/krypto5863/COM3D2_DLC_Checker/master/COM_NewListDLC.lst";
         static readonly string DLC_LIST_PATH = Path.Combine(Directory.GetCurrentDirectory(), "COM_NewListDLC.lst");
+
+        static readonly uint STEAM_APPID_COM3D2INM = 1097580; // CUSTOM ORDER MAID 3D2 It's a Night Magic
 
         static void Main(string[] args)
         {
@@ -124,6 +130,17 @@ namespace COM3D2_DLC_Checker
             if (GAME_DIRECTORY_REGISTRY != null && Directory.Exists(GAME_DIRECTORY_REGISTRY) && File.Exists(Path.Combine(GAME_DIRECTORY_REGISTRY, "COM3D2x64.exe")))
             {
                 return GAME_DIRECTORY_REGISTRY;
+            }
+
+            var handler = new SteamHandler(FileSystem.Shared, WindowsRegistry.Shared);
+            if (handler != null)
+            {
+                var comd3d2 = handler.FindOneGameById(AppId.From(STEAM_APPID_COM3D2INM), out var errors1);
+                if (comd3d2 != null)
+                {
+                    string com3d2inmPath = Path.Combine(comd3d2.Path.ToString(), @"com3d2inm");
+                    return com3d2inmPath;
+                }
             }
 
             CONSOLE_COLOR(ConsoleColor.Yellow, "Warning : COM3D2 installation directory is not set or is set improperly in the registry. Will use current directory");


### PR DESCRIPTION
Uses GameFinder package, which requires some dependencies to be updated:
.NET 8 -> 9 and Microsoft.Win32.Registry 4.7.0 -> 5.0.0